### PR TITLE
Add image content moderation for event uploads via Sightengine

### DIFF
--- a/Final Project Back/.env.example
+++ b/Final Project Back/.env.example
@@ -1,0 +1,21 @@
+# MongoDB
+MONGODB_URI=your_mongodb_connection_string
+
+# Server
+PORT=3000
+CORS_ORIGIN=http://localhost:5173
+
+# Autenticazione
+JWT_SECRET=your_jwt_secret_key
+
+# Cloudinary (upload immagini eventi)
+CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
+CLOUDINARY_API_KEY=your_cloudinary_api_key
+CLOUDINARY_API_SECRET=your_cloudinary_api_secret
+
+# Moderazione immagini (Sightengine — sightengine.com, piano free senza carta)
+# Lasciare IMAGE_MODERATION_ENABLED non impostato o diverso da 'true' per disattivare
+# il controllo in locale/sviluppo senza dover configurare le credenziali Sightengine.
+IMAGE_MODERATION_ENABLED=false
+SIGHTENGINE_API_USER=your_sightengine_api_user
+SIGHTENGINE_API_SECRET=your_sightengine_api_secret

--- a/Final Project Back/config/sightengine.js
+++ b/Final Project Back/config/sightengine.js
@@ -1,0 +1,25 @@
+/*
+ * sightengine.js
+ * Configura le credenziali per la moderazione immagini via Sightengine.
+ * Attivo solo se IMAGE_MODERATION_ENABLED=true; in quel caso le credenziali
+ * sono obbligatorie (fail fast) per non far partire il server in uno stato
+ * a metà configurato.
+ */
+
+const moderationEnabled = process.env.IMAGE_MODERATION_ENABLED === 'true';
+
+if (moderationEnabled) {
+  const requiredVars = ['SIGHTENGINE_API_USER', 'SIGHTENGINE_API_SECRET'];
+  requiredVars.forEach(function(key) {
+    if (!process.env[key]) throw new Error(`Variabile d'ambiente mancante: ${key}`);
+  });
+}
+
+const SIGHTENGINE_CHECK_URL = 'https://api.sightengine.com/1.0/check.json';
+
+module.exports = {
+  moderationEnabled,
+  apiUser: process.env.SIGHTENGINE_API_USER,
+  apiSecret: process.env.SIGHTENGINE_API_SECRET,
+  checkUrl: SIGHTENGINE_CHECK_URL
+};

--- a/Final Project Back/controllers/eventController.js
+++ b/Final Project Back/controllers/eventController.js
@@ -9,6 +9,7 @@ const Utente = require('../models/user.js');
 const { cloudinary } = require('../config/cloudinary.js');
 const { validationResult } = require('express-validator');
 const { extractPublicId } = require('../utils/cloudinaryUtils.js');
+const { moderateUploadedImage } = require('../utils/moderationUtils.js');
 
 // CREA EVENTO: salva un nuovo evento nel database
 exports.createEvento = async function(req, res) {
@@ -22,6 +23,18 @@ exports.createEvento = async function(req, res) {
   }
 
   try {
+    // Controlla il contenuto dell'immagine prima di salvare l'evento: se non idonea,
+    // moderateUploadedImage ha già eliminato l'asset da Cloudinary
+    if (req.file) {
+      const moderazione = await moderateUploadedImage(req.file);
+      if (!moderazione.approved) {
+        const message = moderazione.reason === 'error'
+          ? 'Impossibile verificare l\'immagine in questo momento. Riprova più tardi.'
+          : 'Immagine non consentita: contenuto non idoneo rilevato. Carica un\'altra immagine.';
+        return res.status(422).json({ message });
+      }
+    }
+
     const datiEvento = { ...req.body };
 
     // Se multer ha ricevuto un file immagine, usa l'URL pubblico restituito da Cloudinary
@@ -70,6 +83,17 @@ exports.updateEvento = async function(req, res) {
     });
 
     if (req.file) {
+      // Controlla il contenuto della nuova immagine PRIMA di toccare quella vecchia:
+      // se viene rifiutata, l'evento e l'immagine precedente restano intatti
+      // (l'asset appena rifiutato è già stato eliminato da moderateUploadedImage)
+      const moderazione = await moderateUploadedImage(req.file);
+      if (!moderazione.approved) {
+        const message = moderazione.reason === 'error'
+          ? 'Impossibile verificare l\'immagine in questo momento. Riprova più tardi.'
+          : 'Immagine non consentita: contenuto non idoneo rilevato. Carica un\'altra immagine.';
+        return res.status(422).json({ message });
+      }
+
       // Se l'evento aveva già un'immagine su Cloudinary, la elimina prima di salvare la nuova
       if (evento.image) {
         await cloudinary.uploader.destroy(extractPublicId(evento.image));

--- a/Final Project Back/utils/moderationUtils.js
+++ b/Final Project Back/utils/moderationUtils.js
@@ -1,0 +1,73 @@
+/*
+ * moderationUtils.js
+ * Controlla il contenuto di un'immagine appena caricata su Cloudinary
+ * tramite Sightengine, prima che l'evento venga salvato/aggiornato.
+ * Non lancia mai eccezioni: risolve sempre { approved, reason, detail }
+ * così i controller possono gestire l'esito senza try/catch aggiuntivi.
+ */
+
+const { cloudinary } = require('../config/cloudinary.js');
+const { extractPublicId } = require('./cloudinaryUtils.js');
+const sightengine = require('../config/sightengine.js');
+
+// Sopra questa soglia (0-1) il contenuto viene considerato non idoneo
+const REJECTION_THRESHOLD = 0.5;
+
+// Distrugge l'asset su Cloudinary senza far fallire il chiamante se la destroy stessa va in errore
+async function destroyBestEffort(publicId) {
+  try {
+    await cloudinary.uploader.destroy(publicId);
+  } catch (err) {
+    console.error('[moderation] impossibile eliminare asset dopo rifiuto:', publicId, err.message);
+  }
+}
+
+async function moderateUploadedImage(file) {
+  if (!sightengine.moderationEnabled) {
+    return { approved: true, reason: 'skipped', detail: 'Moderazione disattivata (IMAGE_MODERATION_ENABLED non attivo).' };
+  }
+
+  const publicId = extractPublicId(file.path);
+
+  try {
+    const params = new URLSearchParams({
+      url: file.path,
+      models: 'nudity-2.1,offensive,gore',
+      api_user: sightengine.apiUser,
+      api_secret: sightengine.apiSecret
+    });
+
+    const response = await fetch(`${sightengine.checkUrl}?${params.toString()}`);
+    const result = await response.json();
+
+    if (result.status !== 'success') {
+      console.error('[moderation] Sightengine API error:', result.error || result);
+      await destroyBestEffort(publicId);
+      return { approved: false, reason: 'error', detail: 'Risposta inattesa da Sightengine.' };
+    }
+
+    const scores = [
+      result.nudity?.sexual_activity,
+      result.nudity?.sexual_display,
+      result.nudity?.erotica,
+      result.offensive?.prob,
+      result.gore?.prob
+    ].filter(function(score) { return typeof score === 'number'; });
+
+    const isFlagged = scores.some(function(score) { return score >= REJECTION_THRESHOLD; });
+
+    if (isFlagged) {
+      console.error('[moderation] content rejected:', publicId, { scores });
+      await destroyBestEffort(publicId);
+      return { approved: false, reason: 'rejected', detail: 'Contenuto non idoneo rilevato da Sightengine.' };
+    }
+
+    return { approved: true, reason: 'approved', detail: 'Immagine approvata.' };
+  } catch (err) {
+    console.error('[moderation] Sightengine API error:', err.message);
+    await destroyBestEffort(publicId);
+    return { approved: false, reason: 'error', detail: 'Impossibile verificare l\'immagine in questo momento.' };
+  }
+}
+
+module.exports = { moderateUploadedImage };


### PR DESCRIPTION
Rejects event creation/update when the uploaded image is flagged for explicit nudity, sexual content, or gore, deleting the asset from Cloudinary. Gated behind IMAGE_MODERATION_ENABLED so local/dev works without Sightengine credentials.


Claude-Session: https://claude.ai/code/session_01BphF7WqHoHAFdVX6zuxLrc